### PR TITLE
Moved browserify to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "archiver": "1.x",
     "bluebird": "3.x",
-    "browserify": "13.x",
     "fs-extra": "3.x",
     "globby": "6.x",
     "lodash.union": "4.x",
@@ -50,5 +49,8 @@
   },
   "devDependencies": {
     "standard": "x"
+  },
+  "peerDependencies": {
+    "browserify": ">= 13.x"
   }
 }


### PR DESCRIPTION
This is to allow the user to choose the version of browserify they would like to run