### PR TITLE
Fix artifact zip output object location in serverless 1.18

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -83,11 +83,15 @@ function runBrowserify (data) {
 }
 
 function zip (data) {
+  let outputFile = data.functionObject.artifact
+  if (!outputFile && data.functionObject.package) {
+    outputFile = data.functionObject.package.artifact
+  }
   if (process.env.SLS_DEBUG) {
-    this.serverless.cli.log(`Browserifier: Zipping ${data.outputFolder} to ${data.functionObject.artifact}`)
+    this.serverless.cli.log(`Browserifier: Zipping ${data.outputFolder} to ${outputFile}`)
   }
   return new Bb((resolve, reject) => {
-    const output = fs.createWriteStream(data.functionObject.artifact)
+    const output = fs.createWriteStream(outputFile)
     const archive = archiver.create('zip')
 
     output.on('close', () => resolve(archive.pointer()))


### PR DESCRIPTION
closes #2 

Add support for updated artifact filename/path location in serverless v1.18.0+