### PR TITLE
Properly support browserify 16.1.0 and above

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,17 @@
 root = true
 
-[*.{json,js,yml}]
+[*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
+
+[*.md]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,24 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'script'
+  },
+  env: {
+    node: true,
+    es6: true,
+    jest: true
+  },
+  plugins: [
+    'standard',
+    'prettier'
+  ],
+  extends: [
+    'standard',
+    'prettier',
+    'prettier/standard'
+  ],
+  rules: {
+    'space-before-function-paren': ['error', 'always']
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+Changelog
+=========
+
+v2.1.0
+------
+- Properly support `browserify` versions 16.1.0 and up by using the new `node` option. More info [here](https://github.com/browserify/browserify/pull/1804).
+- Display `browserify` version in use by the plugin.
+- Add _external_ `browserify` config.
+- Make more dependencies version flexible.
+- Major README update.
+
+v2.0.0
+------
+- Make `browserify` a peer dependency.
+
+v1.0.5
+------
+- Improve `serverless` v1.18 support.
+
+v1.0.4
+------
+- Improper npm release, same as v1.0.3.
+
+v1.0.3
+------
+- Use `filesize` to report file size, just as serverless does.

--- a/README.md
+++ b/README.md
@@ -7,39 +7,27 @@ Serverless Browserifier Plugin
 [![NPM downloads][downloads-badge]][npm-url]
 [![standardjs][standardjs-badge]][standardjs-url]
 
-A [Serverless](https://serverless.com) v1 plugin that uses [Browserify][browserify-url] to bundle your Node.js Lambda functions.
-
-This project has been forked from the original [serverless-plugin-browserify][original-plugin] by *Ryan Pendergast* and published under a different name.
+A [Serverless](https://serverless.com) v1 plugin that uses [`browserify`][browserify-url] to bundle your Node.js Lambda functions.
 
 ## Motivation
 
-Lambda functions with smaller code start and run faster.
+Smaller Lambda functions that run faster, with minimal changes to normal serverless configuration.
 
-With the example `package.json` and javascript code below, the default packaging for Node.js lambdas in Serverless produces a zip file that is **11.3 MB**, because it blindly includes all of `node_modules` in the zip package.
+### Smaller and faster
 
-This plugin with 2 lines of configuration produces a zip file that is **400 KB!**
+A project usualy contains several dependencies that are required by different functions in miscellaneous combinations, and packaging it all up for every function generates very large and inefficient bundles. This plugin leverages [`browserify`'s][browserify-url] ability of bundling up all files requested using `require`, generating a single lean file with all that is needed for each specific function.
 
-```json
-...
-  "dependencies": {
-    "aws-sdk": "^2.6.12",
-    "moment": "^2.15.2",
-    "request": "^2.75.0",
-    "rxjs": "^5.0.0-rc.1"
-  },
-...
-```  
+Normal serverless packaging includes all files within the `node_modules` structures, including several files that are not really needed during runtime, like _package.json_ files, documentation files, and much more. And although recent versions of serverless automatically ignore _devDependencies_, you'll certainly still have more dependencies than needed for each single function.
 
-```javascript
-const Rx      = require('rxjs/Rx');
-const request = require('request');
-...
-```
-Even if you choose to manually prepare your packages with `package[include|exclude]`, you will still have to take care of that for each single function individually, and manually. This is specially hard after `npm` 3, due to dependency tree flattening.
+Serverless does support manual preparation of packages, but you will still have to take care of that for each single function individually, which can quickly get out of hand dependending on the number of dependencies you need. This is specially hard after `npm` 3, due to dependency tree flattening.
 
-Also, AWS Lambda has an account-wide [deployment package size limit](http://docs.aws.amazon.com/lambda/latest/dg/limits.html).
+The reduction is package size is, on average, __superior to 90%__. This is important as AWS Lambda has an account-wide [deployment package size limit][lambda-size-limit], and reduces file transfer times.
 
-Mind that [aws-sdk-js](https://github.com/aws/aws-sdk-js) now officially [supports browserify](https://github.com/aws/aws-sdk-js/issues/696). Read more about this in [on this article](https://rynop.wordpress.com/2016/11/01/aws-sdk-for-javascript-now-fully-componentized/).
+Less code to parse also means quicker Lambda [_cold start_][container-reuse].
+
+### Minimal changes
+
+When using this plugin, one of the goals is to reduce serverless configuration changes as much as possible. It must possible to just remove the plugin and resume normal usage of serverless, without any additional modifications.
 
 ## Installation
 
@@ -76,22 +64,88 @@ functions:
     usersGet:
       name: ${self:provider.stage}-${self:service}-pageGet
       description: get user
-      handler: users/handler.hello      
+      handler: users/handler.hello
       browserify:
         noParse:
-          - ./someBig.json  #browserify can't optimize json, will take long time to parse for nothing      
+          - ./someBig.json  #browserify can't optimize json, will take long time to parse for nothing
 ```
 
-If you find a package that is not supported or does not behave well with browserify, you can still use function level `package.include` to include extra modules and files to your package. That said, you are encouraged to verify if you specific case can be dealt with by leveraging all available [browserify options](https://github.com/substack/node-browserify#browserifyfiles--opts) in your `serverless.yml` custom `browserify` section. 
+If you find a package that is not supported or does not behave well with browserify, you can still use function level `package.include` to include extra modules and files to your package. That said, you are encouraged to verify if you specific case can be dealt with by leveraging all available [browserify options][browserify-options] in your `serverless.yml` custom `browserify` section.
+
+You can still use serveless' `package[include|exclude]` options to include extra files within your bundles, if necessary.
 
 ## Usage
 
 When this plugin is enabled, and `package.individually` is `true`, running `serverless deploy` and `serverless deploy -f <funcName>` will automatically browserify your Node.js lambda code.
 
-If you want to see more information about the process, simply set `SLS_DEBUG=*`. Example: 
+If you want to see more information about the process, simply set `SLS_DEBUG=*`. Example:
 ```
 $ export SLS_DEBUG=*
 $ sls deploy function -v -f usersGet
+```
+
+You can also verify your bundles by simply using `sls package`, which bundles everything up but does not deploy.
+
+## Using browserify plugins/transforms
+
+If you want to use browserify plugins, you can easily do that by using the global browserify options. As the plugin merely passes that up to browserify, as if it is calling the main [`browserify`][browserify-options] function, you can use it to add any transformations you want.
+
+Do you want to transpile using TypeScript? No problem! You can use [`tsify`](https://www.npmjs.com/package/tsify):
+
+```yml
+# if you have no transform package options
+custom:
+  browserify:
+    transform:
+      - tsify                    # single dash!
+
+# if you have extra transform package options
+custom:
+  browserify:
+    transform:
+      - - tsify                  # array of array, two dashes!
+        - noImplicitAny: true
+
+# multiple mixed transforms
+custom:
+  browserify:
+    transform:
+      - jstify
+      - - tsify
+        - noImplicitAny: true
+```
+
+<sup>
+PS: For a more in-depth example, please check [this issue](https://github.com/digitalmaas/serverless-plugin-browserifier/issues/8).
+</sup>
+
+## Best practices
+
+__If using it with AWS, use discrete SDK clients!__
+
+The official [aws-sdk-js][aws-sdk] officially [supports browserify][aws-sdk-support]. That allows us to further reduce the size of our bundles (and Lambda memory usage and speed) by loading only what is strictly needed.
+
+```javascript
+// instead of ...
+const AWS = require('aws-sdk')
+const s3 = new AWS.S3()
+// ... you should use ...
+const S3 = require('aws-sdk/clients/s3')
+const s3 = new S3()
+```
+
+__Ignore AWS SDK!__
+
+Although you can use discrete clients (see item above), AWS Lambda service always bundles up the latest SDK version in its Lambda container image. That means that, even if you don't add AWS SDK to your bundle, it will still be available in runtime.
+
+Therefore, if you don't need any specific AWS SDK version, you can add the following to your plugin config:
+
+```yml
+custom:
+  browserify:
+    exclude:
+      - aws-sdk
+      - aws-sdk/clients/s3
 ```
 
 ## FAQ
@@ -100,17 +154,26 @@ __Should I use Webpack instead of this plugin?__
 
 Browserify, in general, supports more modules, optimises better (generates smaller bundles), and requires less configuration. [Webpack][webpack-github] is an amazing tool, but it comes with several extras that are not really needed within a pure Node.js environment.
 
-__What about uglification?__
+__What about uglification? And babel?__
 
-You should be able to use [`uglify-es`][uglify-url] through [`uglifyify`][uglifyify-url].
+You should be able to use [`uglify-es`][uglify-url] through [`uglifyify`][uglifyify-url]. For babel usage, [`babelify`][babelify-url] should do the trick. Refer back to [_Using browserify plugins_](#using-browserify-pluginstransforms) section to set it up.
 
-__And what about babel?__
+__Avoid mixing this plugin with other plugins that modify serverless' packaging behaviour!__
 
-I believe that [`babelify`][babelify-url] should do the trick, although I don't see any reason for it. AWS Lambda already supports Node.js 6.10, with enough ES-next goodies that allows us to avoid transpilers.
+This plugin _hijacks_ the normal serverless packaging process, so it will probably conflict with other plugins that use similar mechanisms.
+
+## Useful information
+
+- [List of browserify's transforms][useful-transforms-list]
+- [A curated list of awesome Browserify resources, libraries, and tools.][useful-browserify-resources]
+
 
 ## License
 
-MIT License.    
+MIT License.
+
+This project has been forked from the original [serverless-plugin-browserify][original-plugin] and published under a different name, as the original has been abandoned.
+
 For the complete information, please refer to the [license](./LICENSE) file.
 
 [serverless-badge]: https://img.shields.io/badge/serverless-%E2%9A%A1-yellow.svg?colorB=555555&style=flat-square
@@ -129,3 +192,9 @@ For the complete information, please refer to the [license](./LICENSE) file.
 [uglify-url]: https://www.npmjs.com/package/uglify-es
 [uglifyify-url]: https://www.npmjs.com/package/uglifyify
 [babelify-url]: https://www.npmjs.com/package/babelify
+[aws-sdk]: https://github.com/aws/aws-sdk-js
+[aws-sdk-support]: https://github.com/aws/aws-sdk-js/issues/696
+[container-reuse]: https://aws.amazon.com/blogs/compute/container-reuse-in-lambda/
+[lambda-size-limit]: http://docs.aws.amazon.com/lambda/latest/dg/limits.html
+[useful-transforms-list]: https://github.com/browserify/browserify/wiki/list-of-transforms
+[useful-browserify-resources]: https://github.com/browserify/awesome-browserify

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const Bb = require('bluebird')
+const Promise = require('bluebird')
 const browserify = require('browserify')
 const archiver = require('archiver')
 const filesize = require('filesize')
 const globby = require('globby')
 const path = require('path')
 
-const fs = Bb.promisifyAll(require('fs-extra'))
+const fs = Promise.promisifyAll(require('fs-extra'))
 
 /// //////////////////////// exports && main functions
 
@@ -19,9 +19,9 @@ module.exports = {
 function bundle (functionName) {
   const data = this.functionConfigCache[functionName]
   if (!(data)) {
-    return Bb.resolve()
+    return Promise.resolve()
   }
-  return Bb
+  return Promise
     .bind(this)
     .return(data)
     .then(prepareIncludes)
@@ -31,14 +31,14 @@ function bundle (functionName) {
 }
 
 function bootstrap (functionName) {
-  return Bb
+  if (process.env.SLS_DEBUG) {
+    this.serverless.cli.log(`Browserifier: Preparing ${functionName}...`)
+  }
+  return Promise
     .bind(this)
     .return(functionName)
     .then(prepareInitialData)
     .then(fixServerlessConfig)
-    .tap(() => {
-      this.serverless.cli.log(`Browserifier: Preparing ${functionName}...`)
-    })
 }
 
 /// //////////////////////// support functions
@@ -75,15 +75,17 @@ function runBrowserify (data) {
   if (process.env.SLS_DEBUG) {
     this.serverless.cli.log(`Browserifier: Writing browserified bundle to ${data.outputFolder}`)
   }
-  const b = browserify(data.functionBrowserifyConfig)
-  data.functionBrowserifyConfig.exclude.forEach(file => b.exclude(file))
-  data.functionBrowserifyConfig.ignore.forEach(file => b.ignore(file))
-  return Bb
+  const cfg = data.functionBrowserifyConfig
+  const b = browserify(cfg)
+  cfg.exclude.forEach(file => b.exclude(file))
+  cfg.ignore.forEach(file => b.ignore(file))
+  cfg.external.forEach(file => b.external(file))
+  return Promise
     .fromCallback(cb => b.bundle(cb))
     .then(bundleBuffer => {
       const handlerPath = path.join(data.outputFolder, data.functionObject.handler.split('.')[0] + '.js')
       fs.mkdirsSync(path.dirname(handlerPath), '0777') // handler may be in a subdir
-      return Bb.fromCallback(cb => fs.writeFile(handlerPath, bundleBuffer, cb))
+      return Promise.fromCallback(cb => fs.writeFile(handlerPath, bundleBuffer, cb))
     })
     .return(data)
 }
@@ -93,7 +95,7 @@ function zip (data) {
   if (process.env.SLS_DEBUG) {
     this.serverless.cli.log(`Browserifier: Zipping ${data.outputFolder} to ${outputFile}`)
   }
-  return new Bb((resolve, reject) => {
+  const handleStream = (resolve, reject) => {
     const output = fs.createWriteStream(outputFile)
     const archive = archiver.create('zip')
 
@@ -103,8 +105,8 @@ function zip (data) {
     archive.pipe(output)
     archive.directory(data.outputFolder, '')
     archive.finalize()
-  })
-  .then(sizeInBytes => {
+  }
+  return new Promise(handleStream).then(sizeInBytes => {
     this.serverless.cli.log(`Browserifier: Created ${data.functionName}.zip (${filesize(sizeInBytes)})...`)
     return data
   })

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -17,27 +17,7 @@ module.exports = {
       throw new this.serverless.classes.Error('custom.browserify.disable is true in serverless.yml', 'skip')
     }
 
-    let globalDefault = {  // Browserify plugin config
-      disable: false, // Not an official option, used as internal option to skip browserify
-      exclude: [],    // Not an option, but will use for setting browserify.exclude() if defined in yml
-      include: [],    // Not an option, but will use for setting browserify.include() if defined in yml
-      ignore: [],     // Not an option, but will use for setting browserify.ignore() if defined in yml
-
-      basedir: this.serverless.config.servicePath,
-      entries: [],
-      standalone: 'lambda',
-      browserField: false,  // Setup for node app (copy logic of --node in bin/args.js)
-      builtins: false,
-      commondir: false,
-      ignoreMissing: true,  // Do not fail on missing optional dependencies
-      detectGlobals: true,  // We don't care if its slower, we want more mods to work
-      insertGlobalVars: {      // Handle process https://github.com/substack/node-browserify/issues/1277
-        // __filename: insertGlobals.lets.__filename,
-        // __dirname: insertGlobals.lets.__dirname,
-        process: () => {}
-      },
-      debug: false
-    }
+    const globalDefault = this.getBrowserifyDefaultConfig()
 
     // Merge in global config
     this.globalBrowserifyConfig = Object.assign({}, globalDefault, globalCustom)
@@ -59,9 +39,65 @@ module.exports = {
   },
 
   /**
+   * Returns plugin default configuration object.
+   * @return {object} Default plugin configuration.
+   */
+  getBrowserifyDefaultConfig () {
+    const version = this.getBrowserifyVersion()
+    if (version < '13.3.0') {
+      throw new this.serverless.classes.Error('Minimal \'browserify\' version supported is v13.3.0.', 'skip')
+    }
+    this.serverless.cli.log('Browserifier: Using browserify@' + version)
+    // Props disable, exclude, include, external and ignore are not browserify
+    // options, but will be used for custom plugin settings if defined in yml
+    const config = {
+      disable: false,
+      exclude: [],
+      include: [],
+      external: [],
+      ignore: [],
+      basedir: this.serverless.config.servicePath,
+      entries: [],
+      standalone: 'lambda',
+      ignoreMissing: true, // Do not fail on missing optional dependencies
+      detectGlobals: true, // We don't care if its slower, we want more mods to work
+      debug: Boolean(process.env.SLS_DEBUG)
+    }
+    if (version >= '16.1.0') {
+      config.node = true
+    } else {
+      Object.assign(config, {
+        browserField: false, // Setup for node app (copy logic of --node in bin/args.js)
+        builtins: false,
+        commondir: false,
+        insertGlobalVars: {
+          process: undefined,
+          global: undefined,
+          Buffer: undefined,
+          'Buffer.isBuffer': undefined
+        }
+      })
+    }
+    return config
+  },
+
+  /**
+   * Return browserify version to be used.
+   * @return {[type]} [description]
+   */
+  getBrowserifyVersion () {
+    try {
+      const pkg = require('browserify/package.json')
+      return pkg.version
+    } catch (err) {
+      throw new this.serverless.classes.Error('Required peer dependency \'browserify\' is not installed.', 'skip')
+    }
+  },
+
+  /**
    * Merge the global base configuration with given lambda function contextual configuration
    *
-   * @param {string} functionName
+   * @param {string} functionName () {}
    * @returns {*}
    */
   getFunctionConfig (functionName) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-browserifier",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Serverless v1 plugin that uses browserify to bundle Node.js lambda functions",
   "main": "index.js",
   "author": "Ricardo Nolde <ricardo@nolde.com.br>",
@@ -20,10 +20,27 @@
   "engines": {
     "node": ">=4.3"
   },
+  "prettier": {
+    "printWidth": 100,
+    "semi": false,
+    "singleQuote": true,
+    "jsxBracketSameLine": true
+  },
+  "lint-staged": {
+    "*.js": [
+      "eslint --fix",
+      "git add"
+    ]
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged",
+      "pre-push": "npm test"
+    }
+  },
   "scripts": {
-    "format": "./node_modules/.bin/standard --fix",
-    "lint": "./node_modules/.bin/standard",
-    "pretest": "npm run lint",
+    "format": "./node_modules/.bin/eslint --fix --ext .js .",
+    "lint": "./node_modules/.bin/eslint --ext .js .",
     "test": "echo \"no tests yet =( \""
   },
   "keywords": [
@@ -32,6 +49,7 @@
     "serverless-plugin",
     "plugin",
     "browserify",
+    "browserify-transform",
     "browserify-tool",
     "bundle",
     "lambda",
@@ -41,17 +59,23 @@
     "node"
   ],
   "dependencies": {
-    "archiver": "2.1.1",
-    "bluebird": "3.x",
-    "filesize": "3.5.11",
-    "fs-extra": "5.0.0",
-    "globby": "7.1.1",
-    "lodash.union": "4.6.0"
+    "archiver": "2.x",
+    "bluebird": "3.5.x",
+    "filesize": "3.x",
+    "fs-extra": "5.x",
+    "globby": "7.x",
+    "lodash.union": "4.x"
   },
   "peerDependencies": {
-    "browserify": ">= 13.3.x"
+    "browserify": ">= 13.3.0"
   },
   "devDependencies": {
-    "standard": "x"
+    "eslint": "4.19.1",
+    "eslint-config-prettier": "3.0.1",
+    "eslint-plugin-prettier": "2.6.2",
+    "husky": "1.0.0-rc.13",
+    "lint-staged": "7.2.2",
+    "prettier": "1.14.2",
+    "standard": "11.0.1"
   }
 }


### PR DESCRIPTION
- Properly support `browserify` versions 16.1.0 and up by using the new  `node` option
    * More info: https://github.com/browserify/browserify/pull/1804
- Display `browserify` version in use by the plugin
- Add _external_ browserify config
- Make more dependencies version flexible
- Major README update
- Properly set up linting
- Some code clean up